### PR TITLE
added pajbot2 banphrase check

### DIFF
--- a/twitchapi.js
+++ b/twitchapi.js
@@ -7,6 +7,7 @@ const HELIX_USERS_URL = "https://api.twitch.tv/helix/users"
 const HELIX_STREAMS_URL = "https://api.twitch.tv/helix/streams"
 
 const BANPHRASE_API_URL = "https://forsen.tv/api/v1/banphrases/test"
+const PB2_BANPHRASE_API_URL = "https://paj.pajbot.com/api/channel/22484632/moderation/check_message?message=";
 
 exports.getUserId = async (username) => {
     let data;
@@ -38,5 +39,6 @@ exports.isLive = async (username) => {
 
 exports.isBannedPhrase = async (phrase) => {
     const response = await axios.post(BANPHRASE_API_URL, { message: phrase }, { headers: { "Content-Type": "application/json" } })
-    return response.data.banned
+    const pb2response = await axios.get(PB2_BANPHRASE_API_URL+encodeURIComponent(phrase));
+    return response.data.banned || pb2response.data.banned;
 }


### PR DESCRIPTION
In addition to the "standard" pajbot1 there is also a pajbot2 running in foren's channel which check for additional things, such as message height. With this added check your bot wont get timed out for tall messages in "rwl" commands with are under the 250 character limit you set for "tall messages" but are otherwise tall as fuck becuase they are "NaM TaxiBro" spam.
Querying it is quite straightforward, just add the text after the URLs message parameter and use GET. The reply json will have a "banned" boolean field at its root.